### PR TITLE
Filter yells in addition to voice lines

### DIFF
--- a/ShutUpRhonin.lua
+++ b/ShutUpRhonin.lua
@@ -1,9 +1,13 @@
+local IsRhonin = {
+    ["Rhonin"] = true, -- enUS, deDE, esES, frFR, itIT, ptBR
+    ["Ронин"] = true, -- ruRU
+    ["로닌"] = true, -- koKR
+    ["罗宁"] = true, -- zhCN
+}
+
 local function RhoninFilter(self, event, msg, author, ...)
-    local lang, channel, author2, flags, zonechannel, channelid, channelbase, langid, lineid, guid = ...
     local zone = C_Map.GetBestMapForUnit("player")
-    local _, _, _, _, _, npcid = strsplit("-", guid or "")
-    npcid = tonumber(npcid)
-    if npcid == 16128 and zone == 125 then -- language independent check
+    if zone == 125 and IsRhonin[author] then -- we're in Dalaran and Rhonin is yelling
         return true -- filter it
     else
         return false, msg, author, ... -- let it pass
@@ -16,7 +20,7 @@ local function OnEvent(self, event, isLogin, isReload)
         for _, yell in pairs(RhoninEvent) do
             MuteSoundFile(yell)
         end
-        ChatFrame_AddMessageEventFilter("CHAT_MSG_YELL", RhoninFilter)
+        ChatFrame_AddMessageEventFilter("CHAT_MSG_MONSTER_YELL", RhoninFilter)
 	end
 end
 

--- a/ShutUpRhonin.lua
+++ b/ShutUpRhonin.lua
@@ -1,9 +1,22 @@
+local function RhoninFilter(self, event, msg, author, ...)
+    local lang, channel, author2, flags, zonechannel, channelid, channelbase, langid, lineid, guid = ...
+    local zone = C_Map.GetBestMapForUnit("player")
+    local _, _, _, _, _, npcid = strsplit("-", guid or "")
+    npcid = tonumber(npcid)
+    if npcid == 16128 and zone == 125 then -- language independent check
+        return true -- filter it
+    else
+        return false, msg, author, ... -- let it pass
+    end
+end
+
 local function OnEvent(self, event, isLogin, isReload)
 	if isLogin or isReload then
         local RhoninEvent = { 559126, 559127, 559128, 559129, 559130, 559131, 559132, 559133, }
         for _, yell in pairs(RhoninEvent) do
             MuteSoundFile(yell)
         end
+        ChatFrame_AddMessageEventFilter("CHAT_MSG_YELL", RhoninFilter)
 	end
 end
 

--- a/ShutUpRhonin.toc
+++ b/ShutUpRhonin.toc
@@ -1,3 +1,5 @@
 ## Interface: 30401
+## Title: ShutUp Rhonin
+## Notes: Silences Rhonin's Algalon RP in Dalaran (sound + yell)
 ## Version: 3.0.4.1.2
 ShutUpRhonin.lua


### PR DESCRIPTION
Originally I implemented it in _true_ locale independent fashion (using npcid and zoneid)
After testing I realized npc chat does not pass the guid argument like player chat so had to switch to name matching for the NPC.

